### PR TITLE
Add test-dir input

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: '.'
+      test-dir:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   terraform:
@@ -26,5 +30,5 @@ jobs:
     - uses: terraform-linters/setup-tflint@v4
     - run: tflint --recursive --chdir=${{ inputs.directory }} -f compact
     - run: terraform -chdir=${{ inputs.directory }} fmt -check -diff -recursive
-    - run: terraform -chdir=${{ inputs.directory }} init -backend=false
-    - run: terraform -chdir=${{ inputs.directory }} validate
+    - run: terraform -chdir=${{ inputs.test-dir || inputs.directory }} init -backend=false
+    - run: terraform -chdir=${{ inputs.test-dir || inputs.directory }} validate

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         terraform_version: ${{ inputs.terraform-version }}
     - uses: terraform-linters/setup-tflint@v4
-    - run: tflint --recursive --chdir=${{ inputs.directory }} -f compact --recursive
+    - run: tflint --recursive --chdir=${{ inputs.directory }} -f compact
     - run: terraform -chdir=${{ inputs.directory }} fmt -check -diff -recursive
     - run: terraform -chdir=${{ inputs.directory }} init -backend=false
     - run: terraform -chdir=${{ inputs.directory }} validate

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Static code analysis for Terraform. Performs the following checks:
 - terraform fmt -check
 - terraform validate
 - tflint
+
+Inputs:
+
+- terraform-version -- Version of Terraform to use for `terraform fmt`, `terraform init`, and `terraform validate`. Defaults to latest version.
+- directory -- Run checks in this directory, relative to project root. Defaults to project root.
+- test-dir -- If specified, `terraform init` and `terraform validate` will run in this directory. Otherwise, they will run in the directory specified by the `directory` input. This is useful for a reusable module that has a test directory containing test or example code that can be used as a root module containing the module to be tested.


### PR DESCRIPTION
### Added
- Added a `test-dir` input to the Terraform workflow to be used on reusable modules with a test directory.